### PR TITLE
Fix incorrect int64 conversion test

### DIFF
--- a/sheeter/utils/convert_test.go
+++ b/sheeter/utils/convert_test.go
@@ -115,7 +115,7 @@ func (this *SuiteConvert) TestStrToInt64() {
 	assert.Nil(this.T(), err)
 	assert.Equal(this.T(), int64(0), value)
 
-	_, err = StrToInt32(testdata.Unknown)
+	_, err = StrToInt64(testdata.Unknown)
 	assert.NotNil(this.T(), err)
 }
 


### PR DESCRIPTION
## Summary
- fix incorrect call in TestStrToInt64

## Testing
- `go test ./...` *(fails: fetching dependencies forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683fb3074e44832e998ada4b5e248205