### PR TITLE
Fix typo in float conversion test

### DIFF
--- a/sheeter/utils/convert_test.go
+++ b/sheeter/utils/convert_test.go
@@ -141,7 +141,7 @@ func (this *SuiteConvert) TestStrToFloat32() {
 	assert.Nil(this.T(), err)
 	assert.Equal(this.T(), float32(0), value)
 
-	_, err = StrToFloat64(testdata.Unknown)
+	_, err = StrToFloat32(testdata.Unknown)
 	assert.NotNil(this.T(), err)
 }
 


### PR DESCRIPTION
## Summary
- correct negative case for `StrToFloat32` in tests

## Testing
- `go test ./...` *(fails: forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_683fc6c5fc20832e9f9ed1dede283d55